### PR TITLE
examples: add $(DEVKITPRO)/tools/bin to path

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -14,7 +14,7 @@ endif
 
 DEVKITARM  = $(DEVKITPRO)/devkitARM
 LIBGBA     = $(DEVKITPRO)/libgba
-export PATH := $(DEVKITARM)/bin:$(PATH)
+export PATH := $(DEVKITARM)/bin:$(DEVKITPRO)/tools/bin:$(PATH)
 
 PIMPMOBILE = ..
 


### PR DESCRIPTION
This is where gbafix and the gbfs tools reside these days, it seems.

This fixes the build on Linux for me.